### PR TITLE
fixed mapping on yam seeds set per fruit trait

### DIFF
--- a/yam-trait-ontology_withcropname.obo
+++ b/yam-trait-ontology_withcropname.obo
@@ -374,7 +374,7 @@ id: CO_343:0000180
 name: yam seeds set per fruit trait
 def: "Number of seeds developed per fruit after hand flowers pollination" [CO:curators]
 synonym: "SdSet" EXACT []
-is_a: TO:0000894
+is_a: TO:0000445 ! fruit seed number
 
 [Term]
 id: CO_343:0000183


### PR DESCRIPTION
id: CO_343:0000180: yam seeds set per fruit trait
is_a: TO:0000445 ! fruit seed number

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in yambase
    - [ ] checked CropOntology
